### PR TITLE
Add ReactionPicker component and api call, but remove from implementation.

### DIFF
--- a/src/api/apiRequests.tsx
+++ b/src/api/apiRequests.tsx
@@ -1,0 +1,5 @@
+import axios, { AxiosPromise } from 'axios';
+
+const API = process.env.REACT_APP_API_URL;
+
+export const getReactions = (): any => axios.get(`${API}/api/reactions`);

--- a/src/components/common/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/common/ReactionPicker/ReactionPicker.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+const ReactionPicker = (props: ReactionPickerProps): React.ReactElement => {
+  const { reactions, cb, definitionId } = props;
+  const [modalOn, setModalOn] = useState(false);
+
+  const pickReaction = (id: number) => {
+    setModalOn(false);
+    cb({ id, definitionId });
+  };
+
+  return (
+    <div className="reaction-picker">
+      <button onClick={() => setModalOn(!modalOn)}>Reaction Picker</button>
+      {modalOn && (
+        <div className="reaction-modal">
+          {reactions.map((reaction) => (
+            <Reaction
+              key={reaction.id}
+              reaction={reaction}
+              pickReaction={pickReaction}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Reaction = (props: ReactionProps): React.ReactElement => {
+  const { reaction, pickReaction } = props;
+  return (
+    <button className="reaction" onClick={() => pickReaction(reaction.id)}>
+      {reaction.content}
+    </button>
+  );
+};
+
+export default ReactionPicker;
+
+interface ReactionPickerProps {
+  reactions: ReactionItem[];
+  cb: (arg0: CbItem) => void;
+  definitionId: number;
+}
+
+interface ReactionProps {
+  reaction: ReactionItem;
+  pickReaction: (id: number) => void;
+}
+
+export interface ReactionItem {
+  id: number;
+  content: string;
+}
+
+interface CbItem {
+  id: number;
+  definitionId: number;
+}

--- a/src/components/common/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/common/ReactionPicker/ReactionPicker.tsx
@@ -45,7 +45,7 @@ export default ReactionPicker;
 
 interface ReactionPickerProps {
   reactions: ReactionItem[];
-  cb: (arg0: ReactionCbItem) => void;
+  cb: (arg0: ReactionDefinitionIdStrings) => void;
   id: number;
 }
 
@@ -59,7 +59,7 @@ export interface ReactionItem {
   content: string;
 }
 
-export interface ReactionCbItem {
+export interface ReactionDefinitionIdStrings {
   reaction: string;
   id: string;
 }

--- a/src/components/common/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/common/ReactionPicker/ReactionPicker.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 
 const ReactionPicker = (props: ReactionPickerProps): React.ReactElement => {
-  const { reactions, cb, definitionId } = props;
+  const { reactions, cb, id } = props;
   const [modalOn, setModalOn] = useState(false);
 
-  const pickReaction = (reactionId: number) => {
+  const pickReaction = (reaction: number) => {
     setModalOn(false);
-    cb({ reactionId, definitionId });
+    cb({ reaction: `${reaction}`, id: `${id}` });
   };
 
   const handleSetModal = (e: React.MouseEvent) => {
@@ -46,7 +46,7 @@ export default ReactionPicker;
 interface ReactionPickerProps {
   reactions: ReactionItem[];
   cb: (arg0: ReactionCbItem) => void;
-  definitionId: number;
+  id: number;
 }
 
 interface ReactionProps {
@@ -60,6 +60,6 @@ export interface ReactionItem {
 }
 
 export interface ReactionCbItem {
-  reactionId: number;
-  definitionId: number;
+  reaction: string;
+  id: string;
 }

--- a/src/components/common/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/common/ReactionPicker/ReactionPicker.tsx
@@ -9,9 +9,14 @@ const ReactionPicker = (props: ReactionPickerProps): React.ReactElement => {
     cb({ reactionId, definitionId });
   };
 
+  const handleSetModal = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setModalOn(!modalOn);
+  };
+
   return (
     <div className="reaction-picker">
-      <button onClick={() => setModalOn(!modalOn)}>Reaction Picker</button>
+      <button onClick={handleSetModal}>Reaction Picker</button>
       {modalOn && (
         <div className="reaction-modal">
           {reactions.map((reaction) => (

--- a/src/components/common/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/common/ReactionPicker/ReactionPicker.tsx
@@ -4,9 +4,9 @@ const ReactionPicker = (props: ReactionPickerProps): React.ReactElement => {
   const { reactions, cb, definitionId } = props;
   const [modalOn, setModalOn] = useState(false);
 
-  const pickReaction = (id: number) => {
+  const pickReaction = (reactionId: number) => {
     setModalOn(false);
-    cb({ id, definitionId });
+    cb({ reactionId, definitionId });
   };
 
   return (
@@ -40,7 +40,7 @@ export default ReactionPicker;
 
 interface ReactionPickerProps {
   reactions: ReactionItem[];
-  cb: (arg0: CbItem) => void;
+  cb: (arg0: ReactionCbItem) => void;
   definitionId: number;
 }
 
@@ -54,7 +54,7 @@ export interface ReactionItem {
   content: string;
 }
 
-interface CbItem {
-  id: number;
+export interface ReactionCbItem {
+  reactionId: number;
   definitionId: number;
 }

--- a/src/components/common/ReactionPicker/index.ts
+++ b/src/components/common/ReactionPicker/index.ts
@@ -1,0 +1,1 @@
+export { default as ReactionPicker } from './ReactionPicker';

--- a/src/components/pages/GameContainer/Game/Guessing.tsx
+++ b/src/components/pages/GameContainer/Game/Guessing.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
 import shuffle from 'shuffle-array';
+import { ReactionPicker } from '../../../common/ReactionPicker';
 import {
-  ReactionCbItem,
+  ReactionDefinitionIdStrings,
   ReactionItem,
 } from '../../../common/ReactionPicker/ReactionPicker';
-
-import { ReactionPicker } from '../../../common/ReactionPicker';
 
 // Get a shuffled list of other players' definitions + the correct one
 const getDefinitions = (
@@ -98,7 +97,7 @@ interface GuessingProps {
     e: React.FormEvent<HTMLFormElement>,
     guess: string,
   ) => void;
-  handleReactionSelection: (choice: ReactionCbItem) => void;
+  handleReactionSelection: (choice: ReactionDefinitionIdStrings) => void;
   lobbyData: any;
   username: string;
   reactions: ReactionItem[];

--- a/src/components/pages/GameContainer/Game/Guessing.tsx
+++ b/src/components/pages/GameContainer/Game/Guessing.tsx
@@ -1,10 +1,5 @@
 import React, { useState } from 'react';
 import shuffle from 'shuffle-array';
-import { ReactionPicker } from '../../../common/ReactionPicker';
-import {
-  ReactionDefinitionIdStrings,
-  ReactionItem,
-} from '../../../common/ReactionPicker/ReactionPicker';
 
 // Get a shuffled list of other players' definitions + the correct one
 const getDefinitions = (
@@ -25,14 +20,7 @@ const getDefinitions = (
 };
 
 const Guessing = (props: GuessingProps): React.ReactElement => {
-  const {
-    lobbyData,
-    username,
-    handleSubmitGuess,
-    reactions,
-    handleReactionSelection,
-    submittedGuess,
-  } = props;
+  const { lobbyData, username, handleSubmitGuess, submittedGuess } = props;
   // Call getDefinitions to set state. Invoking getDefinitions outside of state causes re-shuffling of the list on selction
   const [definitions] = useState(
     getDefinitions(lobbyData.players, username, lobbyData.definition),
@@ -50,18 +38,11 @@ const Guessing = (props: GuessingProps): React.ReactElement => {
       {!submittedGuess && (
         <form onSubmit={(e) => handleSubmitGuess(e, choice)}>
           {definitions.map((definition: any) => (
-            <>
-              <Guess
-                key={definition.id}
-                definition={definition}
-                handleSelectChoice={handleSelectChoice}
-              />
-              <ReactionPicker
-                reactions={reactions}
-                id={definition.id}
-                cb={handleReactionSelection}
-              />
-            </>
+            <Guess
+              key={definition.id}
+              definition={definition}
+              handleSelectChoice={handleSelectChoice}
+            />
           ))}
           <button>Enter Guess</button>
         </form>
@@ -97,10 +78,8 @@ interface GuessingProps {
     e: React.FormEvent<HTMLFormElement>,
     guess: string,
   ) => void;
-  handleReactionSelection: (choice: ReactionDefinitionIdStrings) => void;
   lobbyData: any;
   username: string;
-  reactions: ReactionItem[];
   submittedGuess: boolean;
 }
 

--- a/src/components/pages/GameContainer/Game/Guessing.tsx
+++ b/src/components/pages/GameContainer/Game/Guessing.tsx
@@ -32,6 +32,7 @@ const Guessing = (props: GuessingProps): React.ReactElement => {
     handleSubmitGuess,
     reactions,
     handleReactionSelection,
+    submittedGuess,
   } = props;
   // Call getDefinitions to set state. Invoking getDefinitions outside of state causes re-shuffling of the list on selction
   const [definitions] = useState(
@@ -47,23 +48,26 @@ const Guessing = (props: GuessingProps): React.ReactElement => {
     <div className="guessing game-page">
       <h2>Guessing</h2>
       <p>Word: {lobbyData.word}</p>
-      <form onSubmit={(e) => handleSubmitGuess(e, choice)}>
-        {definitions.map((definition: any) => (
-          <>
-            <Guess
-              key={definition.id}
-              definition={definition}
-              handleSelectChoice={handleSelectChoice}
-            />
-            <ReactionPicker
-              reactions={reactions}
-              definitionId={definition.id}
-              cb={handleReactionSelection}
-            />
-          </>
-        ))}
-        <button>Enter Guess</button>
-      </form>
+      {!submittedGuess && (
+        <form onSubmit={(e) => handleSubmitGuess(e, choice)}>
+          {definitions.map((definition: any) => (
+            <>
+              <Guess
+                key={definition.id}
+                definition={definition}
+                handleSelectChoice={handleSelectChoice}
+              />
+              <ReactionPicker
+                reactions={reactions}
+                id={definition.id}
+                cb={handleReactionSelection}
+              />
+            </>
+          ))}
+          <button>Enter Guess</button>
+        </form>
+      )}
+      {submittedGuess && <p>Waiting on other players to guess...</p>}
     </div>
   );
 };
@@ -98,6 +102,7 @@ interface GuessingProps {
   lobbyData: any;
   username: string;
   reactions: ReactionItem[];
+  submittedGuess: boolean;
 }
 
 interface GuessProps {

--- a/src/components/pages/GameContainer/Game/Guessing.tsx
+++ b/src/components/pages/GameContainer/Game/Guessing.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
 import shuffle from 'shuffle-array';
+import {
+  ReactionCbItem,
+  ReactionItem,
+} from '../../../common/ReactionPicker/ReactionPicker';
+
+import { ReactionPicker } from '../../../common/ReactionPicker';
 
 // Get a shuffled list of other players' definitions + the correct one
 const getDefinitions = (
@@ -20,7 +26,13 @@ const getDefinitions = (
 };
 
 const Guessing = (props: GuessingProps): React.ReactElement => {
-  const { lobbyData, username, handleSubmitGuess } = props;
+  const {
+    lobbyData,
+    username,
+    handleSubmitGuess,
+    reactions,
+    handleReactionSelection,
+  } = props;
   // Call getDefinitions to set state. Invoking getDefinitions outside of state causes re-shuffling of the list on selction
   const [definitions] = useState(
     getDefinitions(lobbyData.players, username, lobbyData.definition),
@@ -37,11 +49,18 @@ const Guessing = (props: GuessingProps): React.ReactElement => {
       <p>Word: {lobbyData.word}</p>
       <form onSubmit={(e) => handleSubmitGuess(e, choice)}>
         {definitions.map((definition: any) => (
-          <Guess
-            key={definition.id}
-            definition={definition}
-            handleSelectChoice={handleSelectChoice}
-          />
+          <>
+            <Guess
+              key={definition.id}
+              definition={definition}
+              handleSelectChoice={handleSelectChoice}
+            />
+            <ReactionPicker
+              reactions={reactions}
+              definitionId={definition.id}
+              cb={handleReactionSelection}
+            />
+          </>
         ))}
         <button>Enter Guess</button>
       </form>
@@ -75,8 +94,10 @@ interface GuessingProps {
     e: React.FormEvent<HTMLFormElement>,
     guess: string,
   ) => void;
+  handleReactionSelection: (choice: ReactionCbItem) => void;
   lobbyData: any;
   username: string;
+  reactions: ReactionItem[];
 }
 
 interface GuessProps {

--- a/src/components/pages/GameContainer/Game/PlayerList.tsx
+++ b/src/components/pages/GameContainer/Game/PlayerList.tsx
@@ -30,15 +30,15 @@ const playerClassName = (lobbyData: any, player: PlayerItem) => {
 };
 
 const PlayerList = (props: PlayerListProps): React.ReactElement => {
+  const { playerId, lobbyData } = props;
+
   return (
     <div className="player-list">
-      {props.lobbyData.players.map((player: PlayerItem) => {
+      {lobbyData.players.map((player: PlayerItem) => {
         return (
-          <p
-            className={playerClassName(props.lobbyData, player)}
-            key={player.id}
-          >
-            {player.username}, score: {player.points}
+          <p className={playerClassName(lobbyData, player)} key={player.id}>
+            {`${playerId === player.id ? '(you)' : ''} ${player.username}`},
+            score: {player.points}
           </p>
         );
       })}
@@ -50,6 +50,7 @@ export default PlayerList;
 
 interface PlayerListProps {
   lobbyData: any;
+  playerId: string;
 }
 
 interface PlayerItem {

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -27,6 +27,7 @@ const GameContainer = (): React.ReactElement => {
     initialReactionSelection,
   );
   const [submittedGuess, setSubmittedGuess] = useState(false);
+  const [playerId, setPlayerId] = useState('');
 
   // API calls
   useEffect(() => {
@@ -50,6 +51,9 @@ const GameContainer = (): React.ReactElement => {
       setSubmittedGuess(false);
       setReactionSelection(initialReactionSelection);
       console.log(socketData);
+    });
+    socket.on('welcome', (socketData: any) => {
+      setPlayerId(socketData);
     });
   }, []);
 
@@ -169,7 +173,7 @@ const GameContainer = (): React.ReactElement => {
       {lobbyData.phase !== 'LOBBY' && (
         <>
           <p>Room Code: {lobbyCode}</p>
-          <PlayerList lobbyData={lobbyData} />
+          <PlayerList lobbyData={lobbyData} playerId={playerId} />
         </>
       )}
       {currentPhase()}

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -1,6 +1,7 @@
 import React, { SetStateAction, useEffect, useState } from 'react';
 import io from 'socket.io-client';
 import { getReactions } from '../../../api/apiRequests';
+import { ReactionCbItem } from '../../common/ReactionPicker/ReactionPicker';
 
 import {
   Lobby,
@@ -21,6 +22,7 @@ const GameContainer = (): React.ReactElement => {
   const [isHost, setIsHost] = useState(false);
   const [lobbyData, setLobbyData] = useState({ phase: 'LOBBY', players: [] });
   const [reactions, setReactions] = useState([]);
+  const [reactionSelection, setReactionSelection] = useState([]);
 
   // API calls
   useEffect(() => {
@@ -87,6 +89,11 @@ const GameContainer = (): React.ReactElement => {
     socket.emit('play again', lobbyCode);
   };
   ////
+  // handler functions not related to sockets
+  const handleReactionSelection = (choice: ReactionCbItem) => {
+    const { reactionId, definitionId } = choice;
+    console.log(choice);
+  };
 
   const currentPhase = () => {
     switch (lobbyData.phase) {
@@ -111,6 +118,8 @@ const GameContainer = (): React.ReactElement => {
             lobbyData={lobbyData}
             username={username}
             handleSubmitGuess={handleSubmitGuess}
+            handleReactionSelection={handleReactionSelection}
+            reactions={reactions}
           />
         );
       case 'POSTGAME':

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -1,20 +1,19 @@
 import React, { SetStateAction, useEffect, useState } from 'react';
 import io from 'socket.io-client';
 import { getReactions } from '../../../api/apiRequests';
-import { ReactionCbItem } from '../../common/ReactionPicker/ReactionPicker';
-
+import { ReactionDefinitionIdStrings } from '../../common/ReactionPicker/ReactionPicker';
 import {
+  Guessing,
   Lobby,
   PlayerList,
+  Postgame,
   Pregame,
   Writing,
-  Guessing,
-  Postgame,
 } from './Game';
 
 const socket = io.connect(process.env.REACT_APP_API_URL as string);
 const initialLobbyData = { phase: 'LOBBY', players: [] };
-const initialReactionSelection = [] as ReactionCbItem[];
+const initialReactionSelection = [] as ReactionDefinitionIdStrings[];
 
 const GameContainer = (): React.ReactElement => {
   const [username, setUsername] = useState(
@@ -99,7 +98,7 @@ const GameContainer = (): React.ReactElement => {
   };
   ////
   // handler functions not related to sockets
-  const handleReactionSelection = (choice: ReactionCbItem) => {
+  const handleReactionSelection = (choice: ReactionDefinitionIdStrings) => {
     let isNew = true;
     const tempSelection = reactionSelection.map((selection) => {
       if (selection.id === choice.id) {

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -1,5 +1,6 @@
 import React, { SetStateAction, useEffect, useState } from 'react';
 import io from 'socket.io-client';
+import { getReactions } from '../../../api/apiRequests';
 
 import {
   Lobby,
@@ -19,6 +20,16 @@ const GameContainer = (): React.ReactElement => {
   const [lobbyCode, setLobbyCode] = useState('');
   const [isHost, setIsHost] = useState(false);
   const [lobbyData, setLobbyData] = useState({ phase: 'LOBBY', players: [] });
+  const [reactions, setReactions] = useState([]);
+
+  // API calls
+  useEffect(() => {
+    if (lobbyData.phase === 'GUESSING') {
+      getReactions()
+        .then((res: any) => setReactions(res.data.available))
+        .catch(() => console.log('error getting reactions'));
+    }
+  }, [lobbyData]);
 
   // Socket event listeners/handlers.
   useEffect(() => {

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -93,7 +93,6 @@ const GameContainer = (): React.ReactElement => {
   };
 
   const handlePlayAgain = () => {
-    console.log('yup');
     socket.emit('play again', lobbyCode);
   };
   ////


### PR DESCRIPTION
Created ReactionPicker component and implemented on each definition guess to allow users to submit reactions to definitions. Ultimately removed these features from implementation due to new plans for app. Keep the component and api function available for now.

- Turn off definition selection after user submits a vote
- Other minor changes, fixes