### PR TITLE
Add Host reveal Results to players. Add Finale basic page component. Add state, socket events.

### DIFF
--- a/src/components/common/PlayerList/PlayerList.tsx
+++ b/src/components/common/PlayerList/PlayerList.tsx
@@ -48,7 +48,7 @@ const playerUserName = (
   return username;
 };
 
-const PlayerList = (): React.ReactElement => {
+const PlayerList = (props: PlayerListProps): React.ReactElement => {
   const playerId = useRecoilValue(playerIdState);
   const lobbyData = useRecoilValue(lobbyState);
 
@@ -62,7 +62,9 @@ const PlayerList = (): React.ReactElement => {
               <p className="player">
                 {playerUserName(lobbyData, player, playerId)}
               </p>
-              <p className="player-score">Score:{player.points}</p>
+              <p className="player-score">
+                Score: {props.hidePoints ? '?' : `${player.points}`}
+              </p>
             </div>
           );
         })}
@@ -71,3 +73,7 @@ const PlayerList = (): React.ReactElement => {
 };
 
 export default PlayerList;
+
+interface PlayerListProps {
+  hidePoints?: boolean;
+}

--- a/src/components/pages/GameContainer/Game/Finale.tsx
+++ b/src/components/pages/GameContainer/Game/Finale.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Finale = (): React.ReactElement => {
+  return <div></div>;
+};
+
+export default Finale;

--- a/src/components/pages/GameContainer/Game/Finale.tsx
+++ b/src/components/pages/GameContainer/Game/Finale.tsx
@@ -1,7 +1,72 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { finaleDefinitionsState, lobbyState } from '../../../../state';
+import {
+  FinaleDefinition,
+  PlayerItem,
+  TopPlayers,
+} from '../../../../types/gameTypes';
+
+const getTopPlayers = (
+  players: PlayerItem[],
+  definitions: FinaleDefinition[],
+): TopPlayers => {
+  // Get the top 3 players by points
+  players = players.sort((a, b) => (a.points < b.points ? 1 : -1));
+  // Make it easy to lookup the definition by player id
+  const definitionDict: { [key: string]: string } = {};
+  definitions.forEach((defItem) => {
+    definitionDict[defItem.playerId] = defItem.definition;
+  });
+  // Create and return TopPlayers
+  return {
+    first: {
+      id: players[0].id,
+      username: players[0].username,
+      points: players[0].points,
+      definition: definitionDict[players[0].id],
+    },
+    second: {
+      id: players[1].id,
+      username: players[1].username,
+      points: players[1].points,
+      definition: definitionDict[players[1].id],
+    },
+    third: {
+      id: players[2].id,
+      username: players[2].username,
+      points: players[2].points,
+      definition: definitionDict[players[2].id],
+    },
+  };
+};
 
 const Finale = (): React.ReactElement => {
-  return <div></div>;
+  const finaleDefinitions = useRecoilValue(finaleDefinitionsState);
+  const lobbyData = useRecoilValue(lobbyState);
+  const [topPlayers] = useState(
+    getTopPlayers(lobbyData.players, finaleDefinitions),
+  );
+
+  return (
+    <div className="postgame game-page">
+      <div className="example-podium second-place">
+        <p>{topPlayers.second.username}</p>
+        <p>{topPlayers.second.points}</p>
+        <p>{topPlayers.second.definition}</p>
+      </div>
+      <div className="example-podium first-place">
+        <p>{topPlayers.first.username}</p>
+        <p>{topPlayers.first.points}</p>
+        <p>{topPlayers.first.definition}</p>
+      </div>
+      <div className="example-podium third-place">
+        <p>{topPlayers.third.username}</p>
+        <p>{topPlayers.third.points}</p>
+        <p>{topPlayers.third.definition}</p>
+      </div>
+    </div>
+  );
 };
 
 export default Finale;

--- a/src/components/pages/GameContainer/Game/Postgame.tsx
+++ b/src/components/pages/GameContainer/Game/Postgame.tsx
@@ -182,7 +182,7 @@ const Postgame = (props: PostgameProps): React.ReactElement => {
             </div>
           </>
         )}
-        <PlayerList />
+        <PlayerList hidePoints={!revealResults} />
       </Player>
     </div>
   );

--- a/src/components/pages/GameContainer/Game/Postgame.tsx
+++ b/src/components/pages/GameContainer/Game/Postgame.tsx
@@ -75,7 +75,12 @@ const getPlayerDictionary = (players: PlayerItem[]): PlayerDictionary => {
 };
 
 const Postgame = (props: PostgameProps): React.ReactElement => {
-  const { handlePlayAgain, handleSetHost } = props;
+  const {
+    handlePlayAgain,
+    handleSetHost,
+    handleRevealResults,
+    handleSetFinale,
+  } = props;
   const resetGuess = useResetRecoilState(playerGuessState);
   const lobbyData = useRecoilValue(lobbyState);
   const revealResults = useRecoilValue(revealResultsState);
@@ -121,10 +126,26 @@ const Postgame = (props: PostgameProps): React.ReactElement => {
           ))}
         </div>
         <div className="endgame-container">
-          <button className="play-again" onClick={handlePlayAgain}>
-            Play Again
-          </button>
-          <SetHost players={lobbyData.players} handleSetHost={handleSetHost} />
+          {!revealResults ? (
+            // Before reveal
+            <>
+              <button onClick={() => handleRevealResults(guesses)}>
+                Reveal Results
+              </button>
+            </>
+          ) : (
+            // After reveal
+            <>
+              <button className="play-again" onClick={handlePlayAgain}>
+                Play Again
+              </button>
+              <button onClick={handleSetFinale}>Go to Finale</button>
+              <SetHost
+                players={lobbyData.players}
+                handleSetHost={handleSetHost}
+              />
+            </>
+          )}
         </div>
       </Host>
       <Player>

--- a/src/components/pages/GameContainer/Game/Pregame.tsx
+++ b/src/components/pages/GameContainer/Game/Pregame.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import { getWords } from '../../../../api/apiRequests';
 import { useLocalStorage } from '../../../../hooks';
 import {
   hostChoiceState,
   lobbySettingsState,
   lobbyState,
+  revealResultsState,
 } from '../../../../state';
 //styles
 import '../../../../styles/components/pages/Pregame.scss';
@@ -25,12 +26,13 @@ const Pregame = (props: PregameProps): React.ReactElement => {
   const [showEditName, setShowEditName] = useState(false);
   const [wordSelection, setWordSelection] = useState<WordItem[]>([]);
   const lobbySettings = useRecoilValue(lobbySettingsState);
+  const [hostChoice, setHostChoice] = useRecoilState(hostChoiceState);
   const lobbyData = useRecoilValue(lobbyState);
   const [, setGuesses] = useLocalStorage('guesses', []);
   const [useTimer, setUseTimer] = useState<boolean>(
     lobbySettings.seconds && lobbySettings.seconds > 0 ? true : false,
   );
-  const [hostChoice, setHostChoice] = useRecoilState(hostChoiceState);
+  const resetRevealResults = useResetRecoilState(revealResultsState);
 
   const getCurrentWord = () => {
     return wordSelection.filter((word) => word.id === choice)[0];
@@ -39,8 +41,9 @@ const Pregame = (props: PregameProps): React.ReactElement => {
   useEffect(() => {
     // Get 3 word suggestions automatically
     handleGetWords();
-    // Reset guesses array from previous game
+    // Reset previous game states
     setGuesses([]);
+    resetRevealResults();
   }, []);
 
   // Clear choice/input when switching between word selection type

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -24,6 +24,7 @@ import { randomUsername } from '../../../utils/helpers';
 import { Header } from '../../common/Header';
 import { Modal } from '../../common/Modal';
 import { Guessing, Lobby, Postgame, Pregame, Writing } from './Game';
+import Finale from './Game/Finale';
 
 // Create a socket connection to API
 const socket = io.connect(process.env.REACT_APP_API_URL as string);
@@ -340,6 +341,8 @@ const GameContainer = (): React.ReactElement => {
             handleSetFinale={handleSetFinale}
           />
         );
+      case 'FINALE':
+        return <Finale />;
       default:
         return (
           <Lobby

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -4,12 +4,14 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import io from 'socket.io-client';
 import { useLocalStorage } from '../../../hooks';
 import {
+  finaleDefinitionsState,
   hostChoiceState,
   lobbyCodeState,
   lobbySettingsState,
   lobbyState,
   playerGuessState,
   playerIdState,
+  revealResultsState,
 } from '../../../state';
 import {
   DefinitionSelection,
@@ -33,11 +35,13 @@ const GameContainer = (): React.ReactElement => {
   const [lobbyCode, setLobbyCode] = useRecoilState(lobbyCodeState);
   const [lobbySettings, setLobbySettings] = useRecoilState(lobbySettingsState);
   const [playerId, setPlayerId] = useRecoilState(playerIdState);
+  const [, setFinaleDefinitions] = useRecoilState(finaleDefinitionsState);
+  const [, setRevealResults] = useRecoilState(revealResultsState);
+  const hostChoice = useRecoilValue(hostChoiceState);
   const [, setGuesses] = useLocalStorage('guesses', []);
   const [token, setToken] = useLocalStorage('token', '');
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [time, setTime] = useState(-1);
-  const hostChoice = useRecoilValue(hostChoiceState);
   const [, setPlayerGuess] = useRecoilState(playerGuessState);
   const resetLobbyData = useResetRecoilState(lobbyState);
   const resetLobbyCode = useResetRecoilState(lobbyCodeState);
@@ -49,6 +53,8 @@ const GameContainer = (): React.ReactElement => {
     resetLobbyCode();
     resetPlayerGuess();
     setGuesses([]);
+    setFinaleDefinitions([]);
+    setRevealResults(false);
     socket.disconnect();
     setToken('');
     handleLogin(true);
@@ -77,11 +83,17 @@ const GameContainer = (): React.ReactElement => {
     handleLogin();
     //// Socket event listeners
     // Update game each phase, push socket data to state, push lobbyCode to URL
-    socket.on('game update', (socketData: LobbyData) => {
-      setLobbyData(socketData);
-      setLobbyCode(socketData.lobbyCode);
-      history.push(`/${socketData.lobbyCode}`);
-    });
+    socket.on(
+      'game update',
+      (socketData: LobbyData, finaleDefinitions = []) => {
+        setLobbyData(socketData);
+        setLobbyCode(socketData.lobbyCode);
+        history.push(`/${socketData.lobbyCode}`);
+        if (finaleDefinitions.length > 0) {
+          setFinaleDefinitions(finaleDefinitions);
+        }
+      },
+    );
 
     // Add a player to the list when they join
     socket.on('add player', (newPlayer: PlayerItem) => {
@@ -173,6 +185,11 @@ const GameContainer = (): React.ReactElement => {
     socket.on('welcome host', (guesses: GuessItem[]) => {
       setGuesses(guesses);
     });
+
+    socket.on('reveal results', (guesses: GuessItem[]) => {
+      setGuesses(guesses);
+      setRevealResults(true);
+    });
   }, []);
 
   // Socket event emitters
@@ -218,8 +235,16 @@ const GameContainer = (): React.ReactElement => {
     socket.emit('set phase', phase, lobbyCode);
   };
 
+  const handleSetFinale = () => {
+    socket.emit('set finale', lobbyCode);
+  };
+
   const handleSetHost = (hostId: string, guesses: GuessItem[]) => {
     socket.emit('set host', hostId, lobbyCode, guesses);
+  };
+
+  const handleRevealResults = (guesses: GuessItem[]) => {
+    socket.emit('reveal results', lobbyCode, guesses);
   };
 
   const handleUpdateUsername = (newUsername: string) => {

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -336,6 +336,8 @@ const GameContainer = (): React.ReactElement => {
           <Postgame
             handlePlayAgain={handlePlayAgain}
             handleSetHost={handleSetHost}
+            handleRevealResults={handleRevealResults}
+            handleSetFinale={handleSetFinale}
           />
         );
       default:

--- a/src/state/finaleDefinitionsState.ts
+++ b/src/state/finaleDefinitionsState.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { FinaleDefinition } from '../types/gameTypes';
+
+export const finaleDefinitionsState = atom<FinaleDefinition[]>({
+  key: 'finaleDefinitionsState',
+  default: [],
+});

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,3 +1,4 @@
+import { finaleDefinitionsState } from './finaleDefinitionsState';
 import { guessesState } from './guessesState';
 import { hostChoiceState } from './hostChoiceState';
 import { lobbyCodeState } from './lobbyCodeState';
@@ -5,6 +6,7 @@ import { lobbySettingsState } from './lobbySettingsState';
 import { lobbyState } from './lobbyState';
 import { playerGuessState } from './playerGuessState';
 import { playerIdState } from './playerIdState';
+import { revealResultsState } from './revealResultsState';
 import { timerState } from './timerState';
 import { tokenState } from './tokenState';
 
@@ -18,4 +20,6 @@ export {
   timerState,
   hostChoiceState,
   playerGuessState,
+  finaleDefinitionsState,
+  revealResultsState,
 };

--- a/src/state/revealResultsState.ts
+++ b/src/state/revealResultsState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const revealResultsState = atom<boolean>({
+  key: 'revealResultsState',
+  default: false,
+});

--- a/src/types/gameTypes.ts
+++ b/src/types/gameTypes.ts
@@ -7,6 +7,13 @@ export interface PlayerItem {
   connected: boolean;
 }
 
+export interface FinalePlayer {
+  id: string;
+  username: string;
+  points: number;
+  definition: string;
+}
+
 export interface LobbyData {
   definition: string;
   guesses: GuessItem[];
@@ -71,4 +78,10 @@ export interface HostChoice {
 export interface FinaleDefinition {
   playerId: string;
   definition: string;
+}
+
+export interface TopPlayers {
+  first: FinalePlayer;
+  second: FinalePlayer;
+  third: FinalePlayer;
 }

--- a/src/types/gameTypes.ts
+++ b/src/types/gameTypes.ts
@@ -67,3 +67,8 @@ export interface HostChoice {
   word_id_two: number;
   times_shuffled: number;
 }
+
+export interface FinaleDefinition {
+  playerId: string;
+  definition: string;
+}


### PR DESCRIPTION
- Add socket events for 'reveal results' and 'set finale'
- Add conditional rendering on Postgame for when the Host chooses to reveal results to all
- Add conditional display of points on PlayerList
- Add buttons for the Host to reveal results, go to Finale
- Add Finale component that will render on 'FINALE' phase
- Add type interfaces, state