### PR TITLE
Update Finale state and functionality to match API

### DIFF
--- a/src/components/pages/GameContainer/Game/Finale.tsx
+++ b/src/components/pages/GameContainer/Game/Finale.tsx
@@ -31,18 +31,24 @@ const Finale = (): React.ReactElement => {
 
   return (
     <div className="postgame game-page">
-      <div className="example-podium second-place">
-        <p>{topPlayers.second.username}</p>
-        <p>{topPlayers.second.definition}</p>
-      </div>
-      <div className="example-podium first-place">
-        <p>{topPlayers.first.username}</p>
-        <p>{topPlayers.first.definition}</p>
-      </div>
-      <div className="example-podium third-place">
-        <p>{topPlayers.third.username}</p>
-        <p>{topPlayers.third.definition}</p>
-      </div>
+      {topPlayers.second.username !== undefined && (
+        <div className="example-podium second-place">
+          <p>{topPlayers.second.username}</p>
+          <p>{topPlayers.second.definition}</p>
+        </div>
+      )}
+      {topPlayers.first.username !== undefined && (
+        <div className="example-podium first-place">
+          <p>{topPlayers.first.username}</p>
+          <p>{topPlayers.first.definition}</p>
+        </div>
+      )}
+      {topPlayers.third.username !== undefined && (
+        <div className="example-podium third-place">
+          <p>{topPlayers.third.username}</p>
+          <p>{topPlayers.third.definition}</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/pages/GameContainer/Game/Finale.tsx
+++ b/src/components/pages/GameContainer/Game/Finale.tsx
@@ -1,42 +1,26 @@
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { lobbyState } from '../../../../state';
-import {
-  FinaleDefinition,
-  PlayerItem,
-  TopPlayers,
-} from '../../../../types/gameTypes';
+import { LobbyData, TopPlayers } from '../../../../types/gameTypes';
 
-const getTopPlayers = (
-  players: PlayerItem[],
-  definitions: FinaleDefinition[],
-): TopPlayers => {
-  // Get the top 3 players by points
-  players = players.sort((a, b) => (a.points < b.points ? 1 : -1));
-  // Make it easy to lookup the definition by player id
-  const definitionDict: { [key: string]: string } = {};
-  definitions.forEach((defItem) => {
-    definitionDict[defItem.playerId] = defItem.definition;
+const getTopPlayers = (lobbyData: LobbyData): TopPlayers => {
+  const playerDict: { [key: string]: string } = {};
+  lobbyData.players.forEach((player) => {
+    playerDict[player.id] = player.username;
   });
   // Create and return TopPlayers
   return {
     first: {
-      id: players[0].id,
-      username: players[0].username,
-      points: players[0].points,
-      definition: definitionDict[players[0].id],
+      username: playerDict[lobbyData.topThree[0]?.playerId],
+      definition: lobbyData.topThree[0]?.definition,
     },
     second: {
-      id: players[1].id,
-      username: players[1].username,
-      points: players[1].points,
-      definition: definitionDict[players[1].id],
+      username: playerDict[lobbyData.topThree[1]?.playerId],
+      definition: lobbyData.topThree[1]?.definition,
     },
     third: {
-      id: players[2].id,
-      username: players[2].username,
-      points: players[2].points,
-      definition: definitionDict[players[2].id],
+      username: playerDict[lobbyData.topThree[2]?.playerId],
+      definition: lobbyData.topThree[2]?.definition,
     },
   };
 };
@@ -49,17 +33,14 @@ const Finale = (): React.ReactElement => {
     <div className="postgame game-page">
       <div className="example-podium second-place">
         <p>{topPlayers.second.username}</p>
-        <p>{topPlayers.second.points}</p>
         <p>{topPlayers.second.definition}</p>
       </div>
       <div className="example-podium first-place">
         <p>{topPlayers.first.username}</p>
-        <p>{topPlayers.first.points}</p>
         <p>{topPlayers.first.definition}</p>
       </div>
       <div className="example-podium third-place">
         <p>{topPlayers.third.username}</p>
-        <p>{topPlayers.third.points}</p>
         <p>{topPlayers.third.definition}</p>
       </div>
     </div>

--- a/src/components/pages/GameContainer/Game/Finale.tsx
+++ b/src/components/pages/GameContainer/Game/Finale.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { finaleDefinitionsState, lobbyState } from '../../../../state';
+import { lobbyState } from '../../../../state';
 import {
   FinaleDefinition,
   PlayerItem,
@@ -42,11 +42,8 @@ const getTopPlayers = (
 };
 
 const Finale = (): React.ReactElement => {
-  const finaleDefinitions = useRecoilValue(finaleDefinitionsState);
   const lobbyData = useRecoilValue(lobbyState);
-  const [topPlayers] = useState(
-    getTopPlayers(lobbyData.players, finaleDefinitions),
-  );
+  const [topPlayers] = useState(getTopPlayers(lobbyData));
 
   return (
     <div className="postgame game-page">

--- a/src/components/pages/GameContainer/Game/Guessing.tsx
+++ b/src/components/pages/GameContainer/Game/Guessing.tsx
@@ -218,6 +218,8 @@ const Guessing = (props: GuessingProps): React.ReactElement => {
             <p>?</p>
           )}
         </div>
+        <p>Take notes:</p>
+        <textarea maxLength={100} />
         <PlayerList />
       </Player>
     </div>

--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -4,7 +4,6 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import io from 'socket.io-client';
 import { useLocalStorage } from '../../../hooks';
 import {
-  finaleDefinitionsState,
   hostChoiceState,
   lobbyCodeState,
   lobbySettingsState,
@@ -36,7 +35,6 @@ const GameContainer = (): React.ReactElement => {
   const [lobbyCode, setLobbyCode] = useRecoilState(lobbyCodeState);
   const [lobbySettings, setLobbySettings] = useRecoilState(lobbySettingsState);
   const [playerId, setPlayerId] = useRecoilState(playerIdState);
-  const [, setFinaleDefinitions] = useRecoilState(finaleDefinitionsState);
   const [, setRevealResults] = useRecoilState(revealResultsState);
   const hostChoice = useRecoilValue(hostChoiceState);
   const [, setGuesses] = useLocalStorage('guesses', []);
@@ -54,7 +52,6 @@ const GameContainer = (): React.ReactElement => {
     resetLobbyCode();
     resetPlayerGuess();
     setGuesses([]);
-    setFinaleDefinitions([]);
     setRevealResults(false);
     socket.disconnect();
     setToken('');
@@ -84,17 +81,11 @@ const GameContainer = (): React.ReactElement => {
     handleLogin();
     //// Socket event listeners
     // Update game each phase, push socket data to state, push lobbyCode to URL
-    socket.on(
-      'game update',
-      (socketData: LobbyData, finaleDefinitions = []) => {
-        setLobbyData(socketData);
-        setLobbyCode(socketData.lobbyCode);
-        history.push(`/${socketData.lobbyCode}`);
-        if (finaleDefinitions.length > 0) {
-          setFinaleDefinitions(finaleDefinitions);
-        }
-      },
-    );
+    socket.on('game update', (socketData: LobbyData) => {
+      setLobbyData(socketData);
+      setLobbyCode(socketData.lobbyCode);
+      history.push(`/${socketData.lobbyCode}`);
+    });
 
     // Add a player to the list when they join
     socket.on('add player', (newPlayer: PlayerItem) => {

--- a/src/state/finaleDefinitionsState.ts
+++ b/src/state/finaleDefinitionsState.ts
@@ -1,7 +1,0 @@
-import { atom } from 'recoil';
-import { FinaleDefinition } from '../types/gameTypes';
-
-export const finaleDefinitionsState = atom<FinaleDefinition[]>({
-  key: 'finaleDefinitionsState',
-  default: [],
-});

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,4 +1,3 @@
-import { finaleDefinitionsState } from './finaleDefinitionsState';
 import { guessesState } from './guessesState';
 import { hostChoiceState } from './hostChoiceState';
 import { lobbyCodeState } from './lobbyCodeState';
@@ -20,6 +19,5 @@ export {
   timerState,
   hostChoiceState,
   playerGuessState,
-  finaleDefinitionsState,
   revealResultsState,
 };

--- a/src/state/lobbyState.ts
+++ b/src/state/lobbyState.ts
@@ -20,5 +20,6 @@ export const lobbyState = atom<LobbyData>({
         list: [],
       },
     },
+    topThree: [],
   },
 });

--- a/src/types/gameTypes.ts
+++ b/src/types/gameTypes.ts
@@ -8,9 +8,7 @@ export interface PlayerItem {
 }
 
 export interface FinalePlayer {
-  id: string;
   username: string;
-  points: number;
   definition: string;
 }
 
@@ -31,6 +29,7 @@ export interface LobbyData {
       list: unknown[];
     };
   };
+  topThree: FinaleDefinition[];
 }
 
 export interface GuessItem {


### PR DESCRIPTION
- Remove finaleDefinitions variable/state (get from lobbyData as topThree)
- Fix getTopPlayers to match API data
- Update lobbyState default with topThree property
- Add undefined checks for podium div renders