### PR TITLE
Disabled long-polling

### DIFF
--- a/src/components/pages/GameContainer/GameContainer.tsx
+++ b/src/components/pages/GameContainer/GameContainer.tsx
@@ -50,7 +50,7 @@ import { Scoreboard } from '../../common/Scoreboard';
 import { Finale, Guessing, Lobby, Postgame, Pregame, Writing } from './Game';
 
 // Create a socket connection to API
-const socket = io.connect(REACT_APP_API_URL as string);
+const socket = io(REACT_APP_API_URL, { transports: ['websocket'] });
 
 const GameContainer = (): React.ReactElement => {
   const history = useHistory();


### PR DESCRIPTION
# Disable Long-Polling

Socket.io was having issues with long-polling on the new hosting environment, which is on Digital Ocean. As per the instructions and help from Digital Ocean, long-polling was the issue, so they guide to disable it.