### PR TITLE
Disable Long-polling

### DIFF
--- a/src/components/pages/GameContainer/Game/Pregame/AlphaBotSettings.tsx
+++ b/src/components/pages/GameContainer/Game/Pregame/AlphaBotSettings.tsx
@@ -5,7 +5,7 @@ import io from 'socket.io-client';
 import { REACT_APP_API_URL } from '../../../../../utils/constants';
 
 // Create a socket connection to API
-const socket = io.connect(REACT_APP_API_URL as string);
+const socket = io(REACT_APP_API_URL, { transports: ['websocket'] });
 
 const AlphaBotSettings = (props: AlphaBotProps): React.ReactElement => {
   const [enableBot, setEnableBot] = useState(false);


### PR DESCRIPTION
# Disable Long-polling

Socket.io was having issues with long-polling on the new hosting environment, which is on Digital Ocean. As per the instructions and help from Digital Ocean, long-polling was the issue, so they guide to disable it.